### PR TITLE
Fix: Repository 함수 이름 refactoring, TodoRepository/findByUserId 최적화 #36

### DIFF
--- a/plot-server/src/main/java/com/plot/plotserver/repository/CategoryGroupRepository.java
+++ b/plot-server/src/main/java/com/plot/plotserver/repository/CategoryGroupRepository.java
@@ -29,7 +29,7 @@ public interface CategoryGroupRepository extends JpaRepository<CategoryGroup, Lo
     @Query("SELECT DISTINCT cg FROM CategoryGroup cg " +
             "JOIN FETCH cg.categories c " +
             "WHERE cg.user.id = :userId ")
-    public List<CategoryGroup> findByUserIdWithCategories(@Param("userId") Long userId);
+    public List<CategoryGroup> findByUserIdJoinCategories(@Param("userId") Long userId);
 
 //    @Comment("userId로 카테고리 그룹, 카테고리, 태그 정보 조회")
 //    @Query("SELECT DISTINCT cg FROM CategoryGroup cg " +

--- a/plot-server/src/main/java/com/plot/plotserver/repository/CategoryRepository.java
+++ b/plot-server/src/main/java/com/plot/plotserver/repository/CategoryRepository.java
@@ -19,7 +19,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
             "JOIN FETCH c.tagCategories tc "+
             "JOIN FETCH tc.tag t " +
             "WHERE c.id = :id")
-    public Optional<Category> findByIdWithTags(Long id);
+    public Optional<Category> findByIdJoinTags(Long id);
 
     @Query("SELECT c FROM Category c WHERE c.categoryGroup.id = :categoryGroupId AND c.name = :name")
     public Optional<Category> findByNameAndCategoryGroupId(String name, Long categoryGroupId);

--- a/plot-server/src/main/java/com/plot/plotserver/repository/DailyTodoRepository.java
+++ b/plot-server/src/main/java/com/plot/plotserver/repository/DailyTodoRepository.java
@@ -27,7 +27,7 @@ public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
             "JOIN FETCH t.category c " +
             "JOIN FETCH c.categoryGroup cg " +
             "WHERE dt.id = :id")
-    Optional<DailyTodo> findByIdWithTodoAndCategoryAndCategoryGroup(@Param("id") Long id);
+    Optional<DailyTodo> findByIdJoinTodoAndCategoryAndCategoryGroup(@Param("id") Long id);
 
     @Comment("DailyTodo 만 가져오기")
     @Query("SELECT dt FROM DailyTodo dt WHERE dt.todo.id = :todoId AND dt.dailyTodoDate = :dailyTodoDate")
@@ -43,8 +43,8 @@ public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
             "JOIN FETCH dt.todo t " +
             "JOIN FETCH t.category c " +
             "JOIN FETCH c.categoryGroup cg " +
-            "WHERE dt.user.id = :userId AND dt.dailyTodoDate = :dailyTodoDate")
-    public List<DailyTodo> findByUserIDAndDateWithTodoAndCategoryAndCategoryGroup(@Param("userId") Long userId, @Param("dailyTodoDate") LocalDate dailyTodoDate);
+            "WHERE cg.user.id = :userId AND dt.dailyTodoDate = :dailyTodoDate")
+    public List<DailyTodo> findByUserIDAndDateJoinTodoAndCategoryAndCategoryGroup(@Param("userId") Long userId, @Param("dailyTodoDate") LocalDate dailyTodoDate);
 
 
 

--- a/plot-server/src/main/java/com/plot/plotserver/repository/TodoRepository.java
+++ b/plot-server/src/main/java/com/plot/plotserver/repository/TodoRepository.java
@@ -21,7 +21,7 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
             "JOIN FETCH t.category c " +
             "JOIN FETCH c.categoryGroup cg " +
             "WHERE t.id = :id")
-    public Optional<Todo> findByIdWithCategoryAndCategoryGroup(@Param("id") Long id);
+    public Optional<Todo> findByIdJoinCategoryAndCategoryGroup(@Param("id") Long id);
 
 
     @Query("SELECT t FROM Todo t WHERE t.category.id = :categoryId")
@@ -30,13 +30,13 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
     @Query("SELECT t FROM Todo t WHERE t.category.categoryGroup.user.id =:userId")
     public List<Todo> findByUserId(Long userId);
 
-    //이 부분은 최적화가 아닌거 같다.
-//    @Comment("Todo의 Category, CategoryGroup 까지 모두 join해서 가져오기, DailyTodo Add 할 때 사용")
-//    @Query("SELECT t FROM Todo t" +
-//            "FETCH JOIN t.category c" +
-//            "FETCH JOIN c.categoryGroup cg" +
-//            "WHERE t.category.categoryGroup.user.id =:userId")
-//    public List<Todo> findByUserIdByIdWithCategoryAndCategoryGroup(Long userId);
+
+    @Comment("바로 위의 함수와 동일, fetch join 한 버전.")
+    @Query("SELECT t FROM Todo t " +
+            "JOIN FETCH t.category c " +
+            "JOIN FETCH c.categoryGroup cg " +
+            "WHERE t.category.categoryGroup.user.id =:userId")
+    public List<Todo> findByUserIdJoinCategoryAndCategoryGroup(Long userId);
 
 }
 

--- a/plot-server/src/main/java/com/plot/plotserver/service/CategoryGroupService.java
+++ b/plot-server/src/main/java/com/plot/plotserver/service/CategoryGroupService.java
@@ -116,7 +116,7 @@ public class CategoryGroupService {
 //    }
 
     public List<CategoryGroupResponseDto> getAll(Long userId) {
-        List<CategoryGroup> categoryGroupList = categoryGroupRepository.findByUserIdWithCategories(userId);
+        List<CategoryGroup> categoryGroupList = categoryGroupRepository.findByUserIdJoinCategories(userId);
         List<CategoryGroupResponseDto> result = new ArrayList<>();
 
         for (CategoryGroup categoryGroup : categoryGroupList) {
@@ -125,7 +125,7 @@ public class CategoryGroupService {
             for (Category category : categoryGroup.getCategories()) {
 
                 //category마다, 태그까지 join해서 가져오기
-                categoryRepository.findByIdWithTags(category.getId());
+                categoryRepository.findByIdJoinTags(category.getId());
                 CategoryResponseDto.Sub categoryResponse = CategoryResponseDto.Sub.of(category);
                 categoryResponseList.add(categoryResponse);
             }
@@ -157,7 +157,7 @@ public class CategoryGroupService {
 
     public List<CategoryGroupResponseDto.InTodoAdd> getAllCategoryPath(Long userId) {//완료
 
-        List<CategoryGroup> categoryGroupList = categoryGroupRepository.findByUserIdWithCategories(userId);
+        List<CategoryGroup> categoryGroupList = categoryGroupRepository.findByUserIdJoinCategories(userId);
         List<CategoryGroupResponseDto.InTodoAdd> result = new ArrayList<>();
 
         categoryGroupList.forEach(categoryGroup -> {

--- a/plot-server/src/main/java/com/plot/plotserver/service/DailyTodoService.java
+++ b/plot-server/src/main/java/com/plot/plotserver/service/DailyTodoService.java
@@ -53,7 +53,7 @@ public class DailyTodoService {
 
         LocalDate date = LocalDate.parse(sDate);
 
-        List<DailyTodo> dailyTodos = dailyTodoRepository.findByUserIDAndDateWithTodoAndCategoryAndCategoryGroup(userId,date);//todo,category,categorygroup까지 한꺼번에 fetch join해야 할듯
+        List<DailyTodo> dailyTodos = dailyTodoRepository.findByUserIDAndDateJoinTodoAndCategoryAndCategoryGroup(userId,date);//todo,category,categorygroup까지 한꺼번에 fetch join해야 할듯
 
         for (DailyTodo dailyTodo : dailyTodos) {
             Todo todo = dailyTodo.getTodo();
@@ -118,7 +118,7 @@ public class DailyTodoService {
     public DailyTodoResponseWithRecordsDto searchByDailyTodoId(Long dailyToId){//최적화 완료
 
 
-        DailyTodo dailyTodo = dailyTodoRepository.findByIdWithTodoAndCategoryAndCategoryGroup(dailyToId).get();
+        DailyTodo dailyTodo = dailyTodoRepository.findByIdJoinTodoAndCategoryAndCategoryGroup(dailyToId).get();
 
         Todo todo = dailyTodo.getTodo();
         Category category = todo.getCategory();

--- a/plot-server/src/main/java/com/plot/plotserver/service/TodoService.java
+++ b/plot-server/src/main/java/com/plot/plotserver/service/TodoService.java
@@ -94,8 +94,8 @@ public class TodoService {
     }
 
 
-    public List<TodoResponseDto> getAllTodos() {//최적화 해야함.
-        List<Todo> todoList = todoRepository.findByUserId(SecurityContextHolderUtil.getUserId());
+    public List<TodoResponseDto> getAllTodos() {
+        List<Todo> todoList = todoRepository.findByUserIdJoinCategoryAndCategoryGroup(SecurityContextHolderUtil.getUserId());
         List<TodoResponseDto> result = new ArrayList<>();
 
         todoList.forEach(todo -> {
@@ -107,7 +107,7 @@ public class TodoService {
     public TodoResponseWithDailyTodoDto searchByTodoIdJoinHistories(Long todoId, String sDate, DailyTodoResponseWithRecordsDto.Sub temp){//최적화 완료.
 
         try {
-            Todo todo = todoRepository.findByIdWithCategoryAndCategoryGroup(todoId).get();
+            Todo todo = todoRepository.findByIdJoinCategoryAndCategoryGroup(todoId).get();
             TodoResponseWithDailyTodoDto result = TodoResponseWithDailyTodoDto.of(todo,temp);
             return result;
         } catch (Exception e) {

--- a/plot-server/src/test/java/com/plot/plotserver/repository/CategoryGroupRepositoryTest.java
+++ b/plot-server/src/test/java/com/plot/plotserver/repository/CategoryGroupRepositoryTest.java
@@ -200,7 +200,7 @@ class CategoryGroupRepositoryTest {
         em.flush();//db에 쿼리 날리기.
         em.clear();//영속성 컨텍스트 비우기.
 
-        List<CategoryGroup> findGroups = categoryGroupRepository.findByUserIdWithCategories(1L);
+        List<CategoryGroup> findGroups = categoryGroupRepository.findByUserIdJoinCategories(1L);
 
         Category find_category1 = categoryRepository.findById(1L).get();
         Category find_category2 = categoryRepository.findById(2L).get();


### PR DESCRIPTION
- Repository계층 함수 이름 수정.
- TodoRepository/findByUserId 부분 Category, CategoryGroup 까지 fetch join적용하여  최적화.